### PR TITLE
Ignore auctionAddress absence from settings for checkout market.

### DIFF
--- a/src/api/chainApi/rpcClient.ts
+++ b/src/api/chainApi/rpcClient.ts
@@ -107,7 +107,7 @@ export class RpcClient implements IRpcClient {
       contractAddress: this.config?.blockchain.unique.contractAddress,
       escrowAddress: this.config?.blockchain.escrowAddress,
       uniqueSubstrateApiRpc: this.config?.blockchain.unique.wsEndpoint,
-      auctionAddress: this.config?.auction.address,
+      auctionAddress: this.config?.auction?.address,
       nftController: this.nftController
     });
 

--- a/src/api/chainApi/unique/marketController.ts
+++ b/src/api/chainApi/unique/marketController.ts
@@ -76,8 +76,8 @@ class MarketController implements IMarketController {
     this.defaultGasAmount = options.defaultGasAmount || 2500000;
     if (!options.nftController) throw new Error('NFTController not provided');
     this.nftController = options.nftController;
-    if (!options.auctionAddress) throw new Error('Auction address not provided');
-    this.auctionAddress = options.auctionAddress;
+    // if (!options.auctionAddress) throw new Error('Auction address not provided');
+    this.auctionAddress = options.auctionAddress || '';
     const provider = new Web3.providers.WebsocketProvider(this.uniqueSubstrateApiRpc, {
       reconnect: {
         auto: true,


### PR DESCRIPTION
WE don't support auctions from checkout market. Due to that - there is no config related to auctions from BE -> we should be able to run without it.